### PR TITLE
feat: Implement support for Sine v2.3

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -5,7 +5,13 @@
     "homepage": "https://github.com/Darsh-A/Quick-Tab",
     "preferences": "https://raw.githubusercontent.com/Darsh-A/Quick-Tab/refs/heads/main/preferences.json",
     "image": "https://github.com/Darsh-A/Quick-Tab/blob/main/image.png?raw=true",
-    "js": "https://raw.githubusercontent.com/Darsh-A/Quick-Tabs/refs/heads/main/Quick_Tabs.uc.js",
+    "scripts": {
+        "Quick_Tabs.uc.js": {
+            "include": [
+                "chrome://browser/content/browser.xhtml"
+            ]
+        }
+    },
     "readme": "https://raw.githubusercontent.com/Darsh-A/Quick-Tab/refs/heads/main/README.md",
     "author": "Darsh A",
     "version": "1.1.0",


### PR DESCRIPTION
Sine v2.3 implements a new JS structure that previous JS mods do not support automatically, hence why I'm making this pull request.